### PR TITLE
feat: add example todo app on landing page

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,6 +2,7 @@ import Header from "@/components/Header";
 import CheckoutButton from "@/components/CheckoutButton";
 import Footer from "@/components/Footer";
 import { SignInButton, SignUpButton } from "@clerk/nextjs";
+import ExampleApp from "@/components/ExampleApp";
 
 const features = [
   {
@@ -69,6 +70,17 @@ export default function Home() {
                 </div>
               ))}
             </div>
+          </div>
+        </section>
+
+        {/* Example app */}
+        <section className="bg-gray-950 py-24 text-center">
+          <h2 className="text-3xl font-bold text-white">Try it out</h2>
+          <p className="mx-auto mt-4 max-w-md text-gray-400">
+            A tiny todo list to demonstrate the stack in action.
+          </p>
+          <div className="mt-8 flex justify-center">
+            <ExampleApp />
           </div>
         </section>
 

--- a/components/ExampleApp.tsx
+++ b/components/ExampleApp.tsx
@@ -1,0 +1,58 @@
+import { useState } from "react";
+
+export default function ExampleApp() {
+  const [task, setTask] = useState("");
+  const [tasks, setTasks] = useState<string[]>([]);
+
+  const addTask = () => {
+    const trimmed = task.trim();
+    if (!trimmed) return;
+    setTasks([...tasks, trimmed]);
+    setTask("");
+  };
+
+  const removeTask = (index: number) => {
+    setTasks(tasks.filter((_, i) => i !== index));
+  };
+
+  return (
+    <div className="w-full max-w-md rounded-lg bg-gray-800 p-6 shadow-xl">
+      <h3 className="mb-4 text-xl font-semibold text-white">Example Todo App</h3>
+      <div className="flex gap-2">
+        <input
+          value={task}
+          onChange={(e) => setTask(e.target.value)}
+          onKeyDown={(e) => e.key === "Enter" && addTask()}
+          placeholder="Add a task"
+          className="flex-1 rounded-md border border-gray-700 bg-gray-900 px-3 py-2 text-sm text-white placeholder-gray-500 focus:border-indigo-500 focus:outline-none"
+        />
+        <button
+          onClick={addTask}
+          className="rounded-md bg-indigo-600 px-4 py-2 text-sm font-semibold text-white hover:bg-indigo-500"
+        >
+          Add
+        </button>
+      </div>
+      <ul className="mt-4 space-y-2">
+        {tasks.length === 0 && (
+          <li className="text-sm text-gray-400">No tasks yet.</li>
+        )}
+        {tasks.map((t, i) => (
+          <li
+            key={i}
+            className="flex items-center justify-between rounded-md bg-gray-700 px-3 py-2 text-sm text-white"
+          >
+            <span>{t}</span>
+            <button
+              onClick={() => removeTask(i)}
+              className="text-red-400 hover:text-red-300"
+            >
+              Remove
+            </button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add interactive todo demo component
- showcase demo on landing page

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`
- `npm run supabase:test` (fails: Missing NEXT_PUBLIC_SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY environment variables.)

------
https://chatgpt.com/codex/tasks/task_e_68a54820297c8326bbdb2422589735f8