### PR TITLE
fix: mark ExampleApp as client component

### DIFF
--- a/components/ExampleApp.tsx
+++ b/components/ExampleApp.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { useState } from "react";
 
 export default function ExampleApp() {


### PR DESCRIPTION
## Summary
- fix server-client mismatch in `ExampleApp` by marking as a client component

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build` *(fails: Error: Neither apiKey nor config.authenticator provided)*

------
https://chatgpt.com/codex/tasks/task_e_68a54a342e7c8326b175ee18396e7e03