### PR TITLE
Link landing page buttons to auth pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ A minimal foundation for building SaaS products with modern tools like Next.js 1
    ```bash
    npm run dev
    ```
+4. **Open the app and authenticate**
+   Visit http://localhost:3000 and use the Sign up or Sign in links to get started.
 
 ## Testing & Linting
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,8 +1,8 @@
 import Header from "@/components/Header";
 import CheckoutButton from "@/components/CheckoutButton";
 import Footer from "@/components/Footer";
-import { SignInButton, SignUpButton } from "@clerk/nextjs";
 import ExampleApp from "@/components/ExampleApp";
+import Link from "next/link";
 
 const features = [
   {
@@ -42,16 +42,18 @@ export default function Home() {
             configured so you can focus on your product.
           </p>
           <div className="mt-10 flex flex-wrap items-center justify-center gap-4">
-            <SignUpButton mode="modal">
-              <button className="rounded-md bg-white/10 px-6 py-3 text-sm font-semibold text-white hover:bg-white/20">
-                Sign up
-              </button>
-            </SignUpButton>
-            <SignInButton mode="modal">
-              <button className="rounded-md bg-white/10 px-6 py-3 text-sm font-semibold text-white hover:bg-white/20">
-                Sign in
-              </button>
-            </SignInButton>
+            <Link
+              href="/sign-up"
+              className="rounded-md bg-white/10 px-6 py-3 text-sm font-semibold text-white hover:bg-white/20"
+            >
+              Sign up
+            </Link>
+            <Link
+              href="/sign-in"
+              className="rounded-md bg-white/10 px-6 py-3 text-sm font-semibold text-white hover:bg-white/20"
+            >
+              Sign in
+            </Link>
             <CheckoutButton />
           </div>
         </section>
@@ -92,16 +94,18 @@ export default function Home() {
             database in one integrated stack.
           </p>
           <div className="mt-8 flex flex-wrap items-center justify-center gap-4">
-            <SignUpButton mode="modal">
-              <button className="rounded-md bg-white/10 px-6 py-3 text-sm font-semibold text-white hover:bg-white/20">
-                Create account
-              </button>
-            </SignUpButton>
-            <SignInButton mode="modal">
-              <button className="rounded-md bg-white/10 px-6 py-3 text-sm font-semibold text-white hover:bg-white/20">
-                Sign in
-              </button>
-            </SignInButton>
+            <Link
+              href="/sign-up"
+              className="rounded-md bg-white/10 px-6 py-3 text-sm font-semibold text-white hover:bg-white/20"
+            >
+              Create account
+            </Link>
+            <Link
+              href="/sign-in"
+              className="rounded-md bg-white/10 px-6 py-3 text-sm font-semibold text-white hover:bg-white/20"
+            >
+              Sign in
+            </Link>
             <CheckoutButton />
           </div>
         </section>

--- a/app/sign-up/page.tsx
+++ b/app/sign-up/page.tsx
@@ -1,0 +1,9 @@
+import { SignUp } from "@clerk/nextjs";
+
+export default function SignUpPage() {
+  return (
+    <div className="flex flex-col items-center justify-center h-screen gap-2">
+      <SignUp />
+    </div>
+  );
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -2,6 +2,7 @@ import { clerkMiddleware, createRouteMatcher } from '@clerk/nextjs/server'
 
 const publicRoutes = createRouteMatcher([
   '/sign-in',
+  '/sign-up',
   '/api/checkout',
   '/api/webhook',
 ])


### PR DESCRIPTION
## Summary
- Replace nonfunctional hero buttons with links to sign-up and sign-in pages
- Add a dedicated sign-up page and allow unauthenticated access via middleware
- Document how to access the app and authenticate in README

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`
- `npm run build` (fails: Neither apiKey nor config.authenticator provided)
- `npm run supabase:test` (fails: Missing NEXT_PUBLIC_SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY)


------
https://chatgpt.com/codex/tasks/task_e_68a54be78dd883269b716af871c8b5a7